### PR TITLE
タイムゾーンを日本に設定

### DIFF
--- a/compose.prd.yml
+++ b/compose.prd.yml
@@ -9,6 +9,7 @@ services:
       - db
     environment:
       - DATABASE_URL=postgres://user:password@db:5432/discord_messages?sslmode=disable
+      - TZ=Asia/Tokyo
     volumes:
       - .:/app
     command: air

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,8 @@ services:
       - db
     volumes:
       - .:/app
+    environment:
+      - TZ=Asia/Tokyo
     command: air -c .air.toml
 
   db:


### PR DESCRIPTION
- dockerの環境変数にタイムゾーン（Tokyo）を設定